### PR TITLE
Revisit the main loop [DO NOT MERGE - not tested :) ]

### DIFF
--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -24,7 +24,8 @@ options:
   mqtt_port: "1883"
   mqtt_user: ""
   mqtt_pwd: ""
-  send_cmd_retry_delay: "5"
+  send_cmd_retry_delay: "5s"
+  tesla_presence_delay: "3m"
 schema:
   vin: str?
   ble_mac: str?
@@ -33,6 +34,7 @@ schema:
   mqtt_user: str?
   mqtt_pwd: password?
   send_cmd_retry_delay: str?
+  tesla_presence_delay: str?
 # ingress: true
 # panel_icon: mdi:forward
 # backup_exclude:

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -18,25 +18,25 @@ map:
   - share:rw
 startup: services
 options:
-  vin: ""
-  ble_mac: ""
-  debug: false
   mqtt_ip: ""
   mqtt_port: "1883"
   mqtt_user: ""
   mqtt_pwd: ""
-  send_cmd_retry_delay: "5s"
-  tesla_presence_delay: "3m"
+  send_cmd_retry_loop_delay: "5"
+  tesla_presence_loop_delay: "180"
+  debug: false
+  vin: ""
+  ble_mac: ""
 schema:
-  vin: str?
+  mqtt_ip: str
+  mqtt_port: str
+  mqtt_user: "str?"
+  mqtt_pwd: password
+  send_cmd_retry_loop_delay: "int(1,)?"
+  tesla_presence_loop_delay: "int(180,)?"
   debug: bool
-  ble_mac: str?
-  mqtt_ip: str?
-  mqtt_port: str?
-  mqtt_user: str?
-  mqtt_pwd: password?
-  send_cmd_retry_delay: str?
-  tesla_presence_delay: str?
+  vin: str
+  ble_mac: "str?"
 # ingress: true
 # panel_icon: mdi:forward
 # backup_exclude:

--- a/tesla_ble_mqtt/rootfs/app/listen_to_mqtt.sh
+++ b/tesla_ble_mqtt/rootfs/app/listen_to_mqtt.sh
@@ -2,7 +2,7 @@
 
 listen_to_mqtt() {
  echo "Connecting to MQTT server; subscribe topics tesla_ble/+ and homeassistant/status"
- mosquitto_sub --nodelay -E -c -i tesla_ble_mqtt -q 1 -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t tesla_ble/+ -t homeassistant/status -F "%t %p" | \
+ mosquitto_sub --nodelay -c -i tesla_ble_mqtt -q 1 -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t tesla_ble/+ -t homeassistant/status -F "%t %p" | \
   while read -r payload
   do
    topic=$(echo "$payload" | cut -d ' ' -f 1)

--- a/tesla_ble_mqtt/rootfs/app/run.sh
+++ b/tesla_ble_mqtt/rootfs/app/run.sh
@@ -10,8 +10,8 @@ if [ -n "${HASSIO_TOKEN:-}" ]; then
   MQTT_PORT="$(bashio::config 'mqtt_port')"; export MQTT_PORT
   MQTT_USER="$(bashio::config 'mqtt_user')"; export MQTT_USER
   MQTT_PWD="$(bashio::config 'mqtt_pwd')"; export MQTT_PWD
-  SEND_CMD_RETRY_DELAY="$(bashio::config 'send_cmd_retry_delay')"; export SEND_CMD_RETRY_DELAY
-  TESLA_PRESENCE_DELAY="$(bashio::config 'tesla_presence_delay')"; export TESLA_PRESENCE_DELAY
+  SEND_CMD_RETRY_LOOP_DELAY="$(bashio::config 'send_cmd_retry_loop_delay')"; export SEND_CMD_RETRY_LOOP_DELAY
+  TESLA_PRESENCE_LOOP_DELAY="$(bashio::config 'tesla_presence_loop_delay')"; export TESLA_PRESENCE_LOOP_DELAY
   DEBUG="$(bashio::config 'debug')"; export DEBUG
 fi
 
@@ -19,15 +19,15 @@ bashio::log.cyan "tesla_ble_mqtt_docker by Iain Bullock 2024 https://github.com/
 bashio::log.cyan "Inspiration by Raphael Murray https://github.com/raphmur"
 bashio::log.cyan "Instructions by Shankar Kumarasamy https://shankarkumarasamy.blog/2024/01/28/tesla-developer-api-guide-ble-key-pair-auth-and-vehicle-commands-part-3"
 
-bashio::log.green "Configuration Options are:"
-bashio::log.green TESLA_VIN=$TESLA_VIN
-bashio::log.green BLE_MAC=$BLE_MAC
-bashio::log.green MQTT_IP=$MQTT_IP
-bashio::log.green MQTT_PORT=$MQTT_PORT
-bashio::log.green MQTT_USER=$MQTT_USER
-bashio::log.green "MQTT_PWD=Not Shown"
-bashio::log.green SEND_CMD_RETRY_DELAY=$SEND_CMD_RETRY_DELAY
-bashio::log.green TESLA_PRESENCE_DELAY=$TESLA_PRESENCE_DELAY
+bashio::log.green "Configuration Options are:
+  TESLA_VIN=$TESLA_VIN
+  BLE_MAC=$BLE_MAC
+  MQTT_IP=$MQTT_IP
+  MQTT_PORT=$MQTT_PORT
+  MQTT_USER=$MQTT_USER
+  MQTT_PWD=Not Shown
+  SEND_CMD_RETRY_LOOP_DELAY=$SEND_CMD_RETRY_LOOP_DELAY
+  TESLA_PRESENCE_LOOP_DELAY=$TESLA_PRESENCE_LOOP_DELAY"
 
 if [ ! -d /share/tesla_ble_mqtt ]
 then
@@ -48,8 +48,8 @@ send_command() {
     bashio::log.green "Ok"
     break
   else
-    bashio::log.red "Error calling tesla-control, exit code=$EXIT_STATUS - will retry in $SEND_CMD_RETRY_DELAY seconds"
-    sleep $SEND_CMD_RETRY_DELAY
+    bashio::log.red "Error calling tesla-control, exit code=$EXIT_STATUS - will retry in $SEND_CMD_RETRY_LOOP_DELAY seconds"
+    sleep $SEND_CMD_RETRY_LOOP_DELAY
   fi
  done
 }
@@ -66,7 +66,7 @@ send_key() {
     break
   else
     bashio::log.red "COULD NOT SEND THE KEY. Is the car awake and sufficiently close to the bluetooth device?"
-    sleep $SEND_CMD_RETRY_DELAY
+    sleep $SEND_CMD_RETRY_LOOP_DELAY
   fi
  done 
 }
@@ -102,9 +102,9 @@ ble_listening_loop() {
 
  while :
  do
-   bashio::log.green "Launch BLE scanning for car presence every $TESLA_PRESENCE_DELAY"
+   bashio::log.green "Launch BLE scanning for car presence every $TESLA_PRESENCE_LOOP_DELAY"
    listen_to_ble
-   sleep $TESLA_PRESENCE_DELAY
+   sleep $TESLA_PRESENCE_LOOP_DELAY
   fi
  done
 

--- a/tesla_ble_mqtt/translations/en.yaml
+++ b/tesla_ble_mqtt/translations/en.yaml
@@ -11,9 +11,11 @@ configuration:
   mqtt_pwd:
     name: MQTT Password
     description: MQTT User's password
-  send_cmd_retry_delay:
+  send_cmd_retry_loop_delay:
     name: Delay to retry a command
-    description: Delay to retry sending a command to the vehicle over BLE
+    description: Delay time in seconds to retry a command for the vehicle over BLE
+  tesla_presence_loop_delay:
+    description: Delay time in seconds to detect the presence of the vehicle over BLE. HA requires this value to be at least 180s.
   debug:
     name: Debug Logging
     description: Print verbose messages to the log for debugging

--- a/tesla_ble_mqtt/translations/fr.yaml
+++ b/tesla_ble_mqtt/translations/fr.yaml
@@ -11,9 +11,13 @@ configuration:
   mqtt_pwd:
     name: Mot de passe MQTT
     description: Mot de passe de l'utilisateur MQTT
-  send_cmd_retry_delay:
+  send_cmd_retry_loop_delay:
     name: Délai pour re-essayer une commande
-    description: Délai pour re-essayer d'envoyer une command au véhicule via BLE
+    description: Période délai en secondes pour re-essayer une commande pour le véhicule via BLE
+  tesla_presence_loop_delay:
+    name: Délai pour détecter le véhicule
+    description: Période de délai en secondes pour détecter la présence du véhicule via BLE. HA nécessite que cette valeur soit au minimum 180s (3m).
+ least 3m.
   debug:
     name: Journalisation du débogage
     description: Imprimer des messages détaillés dans le journal pour le débogage


### PR DESCRIPTION
- Removed `-E` to mosquitto_sub - this prevents the cmd to exit and the loop to relaunch it non stop. Benefits - reduce resource usage (fork, etc).
- added function `ble_listening_loop` that is launched in background. On add-on restart, the docker instance is stopped and relaunch. Includes a var (delay between each presence) that the end-user can configure. Default is `3m` to reflect the previous ~3m.

- side change... send_cmd_retry_delay default value changed from 5 to 5s

NOT Tested yet. Please comment :)