### PR TITLE
Adjust logging , prevent topic update & ble presence [Splitting in multiple PRs]

### DIFF
--- a/tesla_ble_mqtt/CHANGELOG.md
+++ b/tesla_ble_mqtt/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-WARNING: broken for standalone deployment, stay on 0.0.6a
+WARNING: broken for standalone deployment, stay on 0.0.6
 OK for HA Addon
 
 - logging fix debug and adjustment
@@ -16,6 +16,7 @@ OK for HA Addon
 ### Changed
 
 WARNING: broken for standalone deployment, stay on 0.0.6
+OK for HA Addon
 
 - Bump to latest updates from tesla_ble_mqtt_docker
 - Improve HA logging and error management

--- a/tesla_ble_mqtt/CHANGELOG.md
+++ b/tesla_ble_mqtt/CHANGELOG.md
@@ -1,11 +1,21 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.0.7a
+
+### Changed
+
+WARNING: broken for standalone deployment, stay on 0.0.6a
+OK for HA Addon
+
+- logging fix debug and adjustment
+- prevent always updating presence topic
+- prevent checking for presence if BLE_MAC is empty
+
 ## 0.0.7
 
 ### Changed
 
 WARNING: broken for standalone deployment, stay on 0.0.6
-OK for HA Addon
 
 - Bump to latest updates from tesla_ble_mqtt_docker
 - Improve HA logging and error management

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -27,14 +27,14 @@ options:
   vin: ""
   ble_mac: ""
 schema:
-  mqtt_ip: str?
-  mqtt_port: str?
-  mqtt_user: str?
-  mqtt_pwd: password?
-  send_cmd_retry_delay: str?
+  mqtt_ip: str
+  mqtt_port: str
+  mqtt_user: str
+  mqtt_pwd: password
+  send_cmd_retry_delay: int
   debug: bool
-  vin: str?
-  ble_mac: str?
+  vin: str
+  ble_mac: "str?"
 # ingress: true
 # panel_icon: mdi:forward
 # backup_exclude:

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -18,23 +18,23 @@ map:
   - share:rw
 startup: services
 options:
-  vin: ""
-  ble_mac: ""
-  debug: false
   mqtt_ip: ""
   mqtt_port: "1883"
   mqtt_user: ""
   mqtt_pwd: ""
   send_cmd_retry_delay: "5"
+  debug: false
+  vin: ""
+  ble_mac: ""
 schema:
-  vin: str?
-  debug: bool
-  ble_mac: str?
   mqtt_ip: str?
-  mqtt_port: port
+  mqtt_port: str?
   mqtt_user: str?
   mqtt_pwd: password?
   send_cmd_retry_delay: str?
+  debug: bool
+  vin: str?
+  ble_mac: str?
 # ingress: true
 # panel_icon: mdi:forward
 # backup_exclude:

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla Local Commands"
-version: "0.0.7"
+version: "0.0.7a"
 slug: "tesla_local_commands"
 description: "Local BLE calls to control your Tesla."
 # url: "tbc"
@@ -31,7 +31,7 @@ schema:
   debug: bool
   ble_mac: str?
   mqtt_ip: str?
-  mqtt_port: str?
+  mqtt_port: port
   mqtt_user: str?
   mqtt_pwd: password?
   send_cmd_retry_delay: str?

--- a/tesla_ble_mqtt/rootfs/app/discovery.sh
+++ b/tesla_ble_mqtt/rootfs/app/discovery.sh
@@ -15,7 +15,7 @@ setup_auto_discovery() {
    "name": "Presence",
    "unique_id": "tesla_ble_presence"
   }'
-  
+
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/generate_keys/config -m \
   '{
    "command_topic": "tesla_ble/config",
@@ -31,7 +31,7 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "tesla_ble_generate_keys",
    "entity_category": "config"
-  }' 
+  }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/deploy_key/config -m \
   '{
@@ -48,7 +48,7 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "tesla_ble_deploy_key",
    "entity_category": "config"
-  }' 
+  }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/scan_bluetooth/config -m \
   '{
@@ -65,7 +65,7 @@ setup_auto_discovery() {
    "qos": 1,
    "unique_id": "tesla_ble_scan_bluetooth",
    "entity_category": "diagnostic"
-  }' 
+  }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/wake/config -m \
   '{
@@ -78,9 +78,9 @@ setup_auto_discovery() {
    },
    "name": "Wake Car",
    "payload_press": "wake",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_wake"
-  }' 
+  }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/flash-lights/config -m \
   '{
@@ -93,9 +93,9 @@ setup_auto_discovery() {
    },
    "name": "Flash Lights",
    "payload_press": "flash-lights",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_flash_lights"
-  }'  
+  }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/honk/config -m \
   '{
@@ -108,10 +108,10 @@ setup_auto_discovery() {
    },
    "name": "Honk",
    "payload_press": "honk",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_honk"
-  }' 
- 
+  }'
+
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/lock/config -m \
   '{
    "command_topic": "tesla_ble/command",
@@ -123,9 +123,9 @@ setup_auto_discovery() {
    },
    "name": "Lock Car",
    "payload_press": "lock",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_lock"
-  }' 
+  }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/unlock/config -m \
   '{
@@ -138,9 +138,9 @@ setup_auto_discovery() {
    },
    "name": "Unlock Car",
    "payload_press": "unlock",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_unlock"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/auto_seat-climate/config -m \
   '{
@@ -153,9 +153,9 @@ setup_auto_discovery() {
    },
    "name": "Auto Seat & Climate",
    "payload_press": "auto-seat-and-climate",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_auto_seat-climate"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/climate-off/config -m \
   '{
@@ -168,9 +168,9 @@ setup_auto_discovery() {
    },
    "name": "Climate Off",
    "payload_press": "climate-off",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_climate-off"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/climate-on/config -m \
   '{
@@ -183,7 +183,7 @@ setup_auto_discovery() {
    },
    "name": "Climate On",
    "payload_press": "climate-on",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_climate-on"
    }'
 
@@ -198,10 +198,10 @@ setup_auto_discovery() {
    },
    "name": "Open Trunk",
    "payload_press": "trunk-open",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_trunk-open"
-   }' 
- 
+   }'
+
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/trunk-close/config -m \
   '{
    "command_topic": "tesla_ble/command",
@@ -213,9 +213,9 @@ setup_auto_discovery() {
    },
    "name": "Close Trunk",
    "payload_press": "trunk-close",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_trunk-close"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/frunk-open/config -m \
   '{
@@ -228,9 +228,9 @@ setup_auto_discovery() {
    },
    "name": "Open Frunk",
    "payload_press": "frunk-open",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_frunk-open"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/charging-start/config -m \
   '{
@@ -243,9 +243,9 @@ setup_auto_discovery() {
    },
    "name": "Start Charging",
    "payload_press": "charging-start",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_charging-start"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/charging-stop/config -m \
   '{
@@ -258,9 +258,9 @@ setup_auto_discovery() {
    },
    "name": "Stop Charging",
    "payload_press": "charging-stop",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_charging-stop"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/charge-port-open/config -m \
   '{
@@ -273,9 +273,9 @@ setup_auto_discovery() {
    },
    "name": "Open Charge Port",
    "payload_press": "charge-port-open",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_charge-port-open"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/charge-port-close/config -m \
   '{
@@ -288,10 +288,10 @@ setup_auto_discovery() {
    },
    "name": "Close Charge Port",
    "payload_press": "charge-port-close",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_charge-port-close"
-   }' 
- 
+   }'
+
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/windows-close/config -m \
   '{
    "command_topic": "tesla_ble/command",
@@ -303,10 +303,10 @@ setup_auto_discovery() {
    },
    "name": "Close Windows",
    "payload_press": "windows-close",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_windows-close"
-   }'  
- 
+   }'
+
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/button/tesla_ble/windows-vent/config -m \
   '{
    "command_topic": "tesla_ble/command",
@@ -318,7 +318,7 @@ setup_auto_discovery() {
    },
    "name": "Vent Windows",
    "payload_press": "windows-vent",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_windows-vent"
    }'
 
@@ -339,7 +339,7 @@ setup_auto_discovery() {
    "unit_of_measurement": "A",
    "qos": 1,
    "icon": "mdi:current-ac"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/number/tesla_ble/charging-set-limit/config -m \
   '{
@@ -358,7 +358,7 @@ setup_auto_discovery() {
    "unit_of_measurement": "%",
    "qos": 1,
    "icon": "mdi:battery-90"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/number/tesla_ble/climate-set-temp/config -m \
   '{
@@ -377,7 +377,7 @@ setup_auto_discovery() {
    "unit_of_measurement": "°C",
    "qos": 1,
    "icon": "mdi:temperature"
-   }' 
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/number/tesla_ble/seat-heater/config -m \
   '{
@@ -395,7 +395,7 @@ setup_auto_discovery() {
    "mode": "slider",
    "qos": 1,
    "icon": "mdi:temperature"
-   }'  
+   }'
 
  mosquitto_pub -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t homeassistant/switch/tesla_ble/sw-heater/config -m \
   '{
@@ -407,8 +407,8 @@ setup_auto_discovery() {
     "name": "Tesla_BLE_MQTT"
    },
    "name": "Steering Wheel Heater",
-   "device_class": "switch",  
-   "qos": 1,  
+   "device_class": "switch",
+   "qos": 1,
    "unique_id": "tesla_ble_sw_heater"
    }'
 
@@ -423,7 +423,7 @@ setup_auto_discovery() {
    },
    "name": "Sentry Mode",
    "device_class": "switch",
-   "qos": 1,  
+   "qos": 1,
    "unique_id": "tesla_ble_sentry-mode"
    }'
 

--- a/tesla_ble_mqtt/rootfs/app/listen_to_mqtt.sh
+++ b/tesla_ble_mqtt/rootfs/app/listen_to_mqtt.sh
@@ -1,25 +1,25 @@
 #!/bin/ash
 
 listen_to_mqtt() {
- bashio::log.info "Connecting to MQTT server; subscribe topics tesla_ble/+ and homeassistant/status"
+ bashio::log.debug "Connecting to MQTT server; subscribe topics tesla_ble/+ and homeassistant/status"
  mosquitto_sub --nodelay -E -c -i tesla_ble_mqtt -q 1 -h $MQTT_IP -p $MQTT_PORT -u "$MQTT_USER" -P "$MQTT_PWD" -t tesla_ble/+ -t homeassistant/status -F "%t %p" | \
   while read -r payload
   do
    topic=$(echo "$payload" | cut -d ' ' -f 1)
    msg=$(echo "$payload" | cut -d ' ' -f 2-)
-   bashio::log.green "Received MQTT message: $topic $msg"
+   bashio::log.info "Received MQTT message: $topic $msg"
    case $topic in
     tesla_ble/config)
-     bashio::log.green "Configuration $msg requested"
+     bashio::log.info "Configuration $msg requested"
      case $msg in
       generate_keys)
-       bashio::log.green "Generating the private key"
+       bashio::log.info "Generating the private key"
        openssl ecparam -genkey -name prime256v1 -noout > /share/tesla_ble_mqtt/private.pem
        cat /share/tesla_ble_mqtt/private.pem
-       bashio::log.green "Generating the public key"
+       bashio::log.info "Generating the public key"
        openssl ec -in /share/tesla_ble_mqtt/private.pem -pubout > /share/tesla_ble_mqtt/public.pem
        cat /share/tesla_ble_mqtt/public.pem
-       bashio::log.green "KEYS GENERATED. Next:
+       bashio::log.info "KEYS GENERATED. Next:
        1/ Remove any previously deployed BLE keys from vehicle before deploying this one
        2/ Wake the car up with your Tesla App
        3/ Push the button 'Deploy Key'";;
@@ -27,110 +27,110 @@ listen_to_mqtt() {
        bashio::log.yellow "Deploying public key to vehicle"
         send_key;;
       *)
-       bashio::log.red "Invalid Configuration request. Topic: $topic Message: $msg";;
+       bashio::log.error "Invalid Configuration request. Topic: $topic Message: $msg";;
      esac;;
 
     tesla_ble/command)
-     bashio::log.green "Command $msg requested"
+     bashio::log.info "Command $msg requested"
      case $msg in
        wake)
-        bashio::log.green "Waking Car"
+        bashio::log.info "Waking Car"
         send_command "-domain vcsec $msg";;
        trunk-open)
-        bashio::log.green "Opening Trunk"
+        bashio::log.info "Opening Trunk"
         send_command $msg;;
        trunk-close)
-        bashio::log.green "Closing Trunk"
+        bashio::log.info "Closing Trunk"
         send_command $msg;;
        charging-start)
-        bashio::log.green "Start Charging"
+        bashio::log.info "Start Charging"
         send_command $msg;;
        charging-stop)
-        bashio::log.green "Stop Charging"
+        bashio::log.info "Stop Charging"
         send_command $msg;;
        charge-port-open)
-        bashio::log.green "Open Charge Port"
+        bashio::log.info "Open Charge Port"
         send_command $msg;;
        charge-port-close)
-        bashio::log.green "Close Charge Port"
+        bashio::log.info "Close Charge Port"
         send_command $msg;;
        climate-on)
-        bashio::log.green "Start Climate"
+        bashio::log.info "Start Climate"
         send_command $msg;;
        climate-off)
-        bashio::log.green "Stop Climate"
+        bashio::log.info "Stop Climate"
         send_command $msg;;
        flash-lights)
-        bashio::log.green "Flash Lights"
+        bashio::log.info "Flash Lights"
         send_command $msg;;
        frunk-open)
-        bashio::log.green "Open Frunk"
+        bashio::log.info "Open Frunk"
         send_command $msg;;
        honk)
-        bashio::log.green "Honk Horn"
+        bashio::log.info "Honk Horn"
         send_command $msg;;
        lock)
-        bashio::log.green "Lock Car"
+        bashio::log.info "Lock Car"
         send_command $msg;;
        unlock)
-        bashio::log.green "Unlock Car"
+        bashio::log.info "Unlock Car"
         send_command $msg;;
        windows-close)
-        bashio::log.green "Close Windows"
+        bashio::log.info "Close Windows"
         send_command $msg;;
        windows-vent)
-        bashio::log.green "Vent Windows"
+        bashio::log.info "Vent Windows"
         send_command $msg;;
        *)
-        bashio::log.red "Invalid Command Request. Topic: $topic Message: $msg";;
+        bashio::log.error "Invalid Command Request. Topic: $topic Message: $msg";;
       esac;;
 
     tesla_ble/charging-set-amps)
-     bashio::log.green "Set Charging Amps to $msg requested"
+     bashio::log.info "Set Charging Amps to $msg requested"
      # https://github.com/iainbullock/tesla_ble_mqtt_docker/issues/4
 	 if [ $msg -gt 4 ]; then
-	  bashio::log.green "Set amps"
+	  bashio::log.info "Set amps"
       send_command "charging-set-amps $msg"
 	 else
-      bashio::log.green "First Amp set"
+      bashio::log.info "First Amp set"
       send_command "charging-set-amps $msg"
       sleep 1
-      bashio::log.green "Second Amp set"
+      bashio::log.info "Second Amp set"
       send_command "charging-set-amps $msg"
 	 fi
 	 ;;
 
     tesla_ble/climate-set-temp)
-     bashio::log.green "Set Climate Temp to $msg requested"
+     bashio::log.info "Set Climate Temp to $msg requested"
      send_command "climate-set-temp $msg";;
 
     tesla_ble/seat-heater)
-     bashio::log.green "Set Seat Heater to $msg requested"
+     bashio::log.info "Set Seat Heater to $msg requested"
      send_command "seat-heater $msg";;
 
     tesla_ble/auto-seat-and-climate)
-     bashio::log.green "Start Auto Seat and Climate"
+     bashio::log.info "Start Auto Seat and Climate"
      send_command "auto-seat-and-climate LR on";;
 
     tesla_ble/charging-set-limit)
-     bashio::log.green "Set Charging limit to $msg requested"
+     bashio::log.info "Set Charging limit to $msg requested"
      send_command "charging-set-limit $msg";;
      
     tesla_ble/heated_seat_left)
-     bashio::log.green "Set Seat heater to front-left $msg requested"
+     bashio::log.info "Set Seat heater to front-left $msg requested"
      send_command "seat-heater front-left $msg";;
      
     tesla_ble/heated_seat_right)
-     bashio::log.green "Set Seat heater to front-right $msg requested"
+     bashio::log.info "Set Seat heater to front-right $msg requested"
      send_command "seat-heater front-right $msg";;
 
     homeassistant/status)
      # https://github.com/iainbullock/tesla_ble_mqtt_docker/discussions/6
-     bashio::log.green "Home Assistant is stopping or starting, re-running auto-discovery setup"
+     bashio::log.info "Home Assistant is stopping or starting, re-running auto-discovery setup"
      setup_auto_discovery;;
 
     *)
-     bashio::log.red "Invalid MQTT topic. Topic: $topic Message: $msg";;
+     bashio::log.error "Invalid MQTT topic. Topic: $topic Message: $msg";;
    esac
   done
 }

--- a/tesla_ble_mqtt/rootfs/app/listen_to_mqtt.sh
+++ b/tesla_ble_mqtt/rootfs/app/listen_to_mqtt.sh
@@ -115,11 +115,11 @@ listen_to_mqtt() {
     tesla_ble/charging-set-limit)
      bashio::log.info "Set Charging limit to $msg requested"
      send_command "charging-set-limit $msg";;
-     
+
     tesla_ble/heated_seat_left)
      bashio::log.info "Set Seat heater to front-left $msg requested"
      send_command "seat-heater front-left $msg";;
-     
+
     tesla_ble/heated_seat_right)
      bashio::log.info "Set Seat heater to front-right $msg requested"
      send_command "seat-heater front-right $msg";;

--- a/tesla_ble_mqtt/rootfs/app/run.sh
+++ b/tesla_ble_mqtt/rootfs/app/run.sh
@@ -69,7 +69,7 @@ send_key() {
     bashio::log.yellow "KEY SENT TO VEHICLE: PLEASE CHECK YOU TESLA'S SCREEN AND ACCEPT WITH YOUR CARD"
     break
   else
-    bashio::log.error "tesla-control could not send the key; make sure the car is awake and sufficiently close to the bluetooth device. Retrying in $SEND_CMD_RETRY_DELAY""
+    bashio::log.error "tesla-control could not send the key; make sure the car is awake and sufficiently close to the bluetooth device. Retrying in $SEND_CMD_RETRY_DELAY"
     bashio::log.error "Retrying in $SEND_CMD_RETRY_DELAY"
     sleep $SEND_CMD_RETRY_DELAY
   fi

--- a/tesla_ble_mqtt/rootfs/app/run.sh
+++ b/tesla_ble_mqtt/rootfs/app/run.sh
@@ -71,7 +71,7 @@ send_key() {
     bashio::log.error "Retrying in $SEND_CMD_RETRY_DELAY"
     sleep $SEND_CMD_RETRY_DELAY
   fi
- done 
+ done
 }
 
 PRESENCE_BINARY_SENSOR=OFF

--- a/tesla_ble_mqtt/translations/en.yaml
+++ b/tesla_ble_mqtt/translations/en.yaml
@@ -11,16 +11,15 @@ configuration:
   mqtt_pwd:
     name: MQTT Password
     description: MQTT User's password
-  send_cmd_retry_delay:
-    name: Delay to retry a command
-    description: Delay to retry sending a command to the vehicle over BLE
-  debug:
-    name: Debug Logging
-    description: Print verbose messages to the log for debugging
-vehicle:
   vin:
     name: Car's VIN
     description: Vehicle Identification Number found in Tesla app
   ble_mac:
     name: BLE MAC (optional for proximity detection)
     description: Car's BLE MAC (S___________C); Use Android "BLE scanner" or iOS "nRF Connect"
+  debug:
+    name: Debug Logging
+    description: Print verbose messages to the log for debugging
+  send_cmd_retry_delay:
+    name: Delay to retry a command
+    description: Delay to retry sending a command to the vehicle over BLE

--- a/tesla_ble_mqtt/translations/fr.yaml
+++ b/tesla_ble_mqtt/translations/fr.yaml
@@ -11,16 +11,15 @@ configuration:
   mqtt_pwd:
     name: Mot de passe MQTT
     description: Mot de passe de l'utilisateur MQTT
-  send_cmd_retry_delay:
-    name: Délai pour re-essayer une commande
-    description: Délai pour re-essayer d'envoyer une command au véhicule via BLE
-  debug:
-    name: Journalisation du débogage
-    description: Imprimer des messages détaillés dans le journal pour le débogage
-véhicule:
   vin:
     name: NIV du véhicule
     description: Numéro d'Identification de Véhicule affiché dans l'application Tesla
   ble_mac:
     name: BLE MAC (optionnel pour détection de proximité)
     description: BLE MAC (S___________C) du véhicule; Utiliser Android "BLE scanner" ou iOS "nRF Connect"
+  debug:
+    name: Journalisation du débogage
+    description: Imprimer des messages détaillés dans le journal pour le débogage
+  send_cmd_retry_delay:
+    name: Délai pour re-essayer une commande
+    description: Délai pour re-essayer d'envoyer une command au véhicule via BLE


### PR DESCRIPTION
[EDIT #2] I am splitting this PR in multiple ones.


[EDIT] ready but read this comment and the 2nd one.

1. PR doesn't fix standalone mode, see PR #17 
2. bashio::log debug should now work properly
3. logic to prevent running BLE presence when BLE_MAC is empty
4. logic to prevent always updating presence topic IF value doesn't change

Will test PR later or most likely Tuesday.

Note for 4. :  not sure if value stays on MQTT restart... maybe we need --retain flag or ?!  Worst case, I can remove the logic.