### PR TITLE
Prevent a commit into main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,11 +1,12 @@
 #!/bin/sh
 #
+protected_branch='main'
+current_branch=$(git rev-parse --abbrev-ref HEAD)
 
-# A Git hook script to find and fix trailing white space
-# in your commits. Bypass it with the --no-verify option
-# to git-commit
+# Find and fix trailing white space and tabs
+# Replace tabs with white space
+# Bypass it with the --no-verify option to git-commit
 #
-
 if git rev-parse --verify HEAD >/dev/null 2>&1
 then
     against=HEAD
@@ -29,9 +30,9 @@ do
 # replace whitespace-characters with nothing
 # if first execution of sed-command fails, try second one (Mac OS X version)
     (
-         sed -i -e 's/[ 	]*$//' $FILE > /dev/null 2>&1 \
+         sed -i -e 's/[ 	]*$//g' -e 's/	/        /g' $FILE > /dev/null 2>&1 \
          || \
-         sed -i '' -e 's/[ 	]*$//' $FILE \
+         sed -i '' -e 's/[ 	]*$//g' -e 's/	/        /g' $FILE \
     ) \
     && \
 # (re-)add files that have been altered to Git commit-tree
@@ -40,6 +41,14 @@ do
 done
 # restore $IFS
 IFS="$SAVEIFS"
+
+# Prevent commit on main branch
+#
+if [ $protected_branch = $current_branch ]; then
+  echo "You should not commit to $protected_branch!"
+  echo 'To bypass the protection, add to the git commit command "--no-verify"'
+  exit 1 # push will not execute
+fi
 
 # Exit script with the exit-code of git's check for white space characters
 exec git diff-index --check --cached $against --

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -3,15 +3,13 @@
 protected_branch='main'
 current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
 
-if [ $protected_branch = $current_branch ]
-then
-    read -p "You're about to push to $protected_branch, are you sure? (y/n) " -n 1 -r < /dev/tty
-    echo
-    if echo $REPLY | grep -E '^[Yy]$' > /dev/null
-    then
-        exit 0 # push will execute
-    fi
-    exit 1 # push will not execute
-else
+if [ $protected_branch = $current_branch ]; then
+  read -p "You're about to push to $protected_branch, are you sure? (y/n) " -n 1 -r < /dev/tty
+  echo
+  if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
     exit 0 # push will execute
+  fi
+  exit 1 # push will not execute
+else
+  exit 0 # push will execute
 fi


### PR DESCRIPTION
Earlier commit directly to main added a hook to prevent a "push" to main - but still allowed.

This commit adds to pre-commit hook a second functionality that prevents someone to commit on the main branch. Commit always happen before a push... so it makes sense to have it there and force the user to do a branch.