### PR TITLE
[feat] Auto MAC addr detection

### DIFF
--- a/tesla_ble_mqtt/CHANGELOG.md
+++ b/tesla_ble_mqtt/CHANGELOG.md
@@ -1,12 +1,25 @@
 # Changelog
 
-## 0.1.1
+## 0.2.0
 
 ### Changed
 
-<p>WARNING WARNING WARNING<br>
-DO NOT UPGRADE PRIOR TO READ THE 0.1.0 UPGRADE INSTRUCTIONS<br>
-WARNING WARNING WARNING</p>
+<p>**WARNING WARNING WARNING**<br>
+Upgrading from 0.0.10 or previous? DO NOT UPGRADE PRIOR TO READ THE 0.1.0 UPGRADE INSTRUCTIONS.</p>
+
+- NEW Feature: BLE MAC address auto-detection (unless presence detection is disable)
+- CHG: Removed ble\_mac\_list; obsoleted by mac-auto-detection
+- CHG: Removed scan-bleln-macaddr; obsoleted by mac-auto-detection
+
+## 0.1.2
+
+### Changed
+
+- CHG: Fix allow empty setting BLE MAC addr (Docker standalone)
+
+## 0.1.1
+
+### Changed
 
 - CHG: Fix upgrade forcing to redeploy the key to the car
 

--- a/tesla_ble_mqtt/DOCS.md
+++ b/tesla_ble_mqtt/DOCS.md
@@ -16,7 +16,6 @@ If you have already created a key pair that you want to reuse, place the private
 
 You will need to provide:
 - vin_list : VIN single or multiple separated by either of | , or space; Required
-- ble_mac_list : BLE MAC Addr list single or multiple separated by a | (pipe); Optional for car presence detection
 - presence_detection_loop_delay: The delay between each time the process checks for the presence of your car(s)
 - presence_detection_ttl : TTL in seconds when car is considered gone after last received BLE advertisement; 0 to disable detection
 - mqtt_server : Hostname or IP of your MQTT server; Default 127.0.0.1
@@ -25,8 +24,6 @@ You will need to provide:
 - mqtt_password : MQTT Password
 - ble_cmd_retry_delay : Delay to retry sending a command to the car over BLE; Default 5
 - Start the add-on, check the logs for anything suspecious.
-
-ATTENTION: If you have multiple cars and require presence detection, the cars' position in vin_list vin{n} must match the position in the ble_mac_list. In other words, the BLE MAC Addr in the 2nd position must match the same car's VIN in the 2nd position of the tesla_vin_list.
 
 ## 1.2 For the standalone Docker version please see https://github.com/tesla-local-control/tesla_ble_mqtt_docker
 

--- a/tesla_ble_mqtt/config.yaml
+++ b/tesla_ble_mqtt/config.yaml
@@ -1,5 +1,5 @@
 name: "Tesla Local Commands"
-version: "0.1.1"
+version: "0.2.0"
 slug: "tesla_local_commands"
 description: "Local BLE calls to control your Tesla."
 url: "https://github.com/tesla-local-control/tesla-local-control-addon"
@@ -18,7 +18,6 @@ map:
 startup: services
 options:
   vin_list: ""
-  ble_mac_list: ""
   mqtt_server: ""
   mqtt_port: "1883"
   mqtt_username: ""
@@ -26,7 +25,6 @@ options:
 
 schema:
   vin_list: 'match(^([A-HJ-NPR-Z0-9]{17})(\|[A-HJ-NPR-Z0-9]{17})*$)'
-  ble_mac_list: 'match(^([0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5})(\|[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5})*$)?'
   mqtt_server: str
   mqtt_port: str?
   mqtt_username: str?

--- a/tesla_ble_mqtt/libproduct.sh
+++ b/tesla_ble_mqtt/libproduct.sh
@@ -4,7 +4,6 @@
 function initConfigVariables() {
 
   ### Required Configuration Settings
-  export BLE_MAC_LIST="$(bashio::config 'ble_mac_list')"
   export MQTT_SERVER="$(bashio::config 'mqtt_server')"
   export MQTT_PORT="$(bashio::config 'mqtt_port')"
   export MQTT_USERNAME="$(bashio::config 'mqtt_username')"
@@ -41,6 +40,8 @@ function initConfigVariables() {
 
   # Prevent bashio to complain for "unbound variable"
   export BLE_LN_LIST=""
+  export BLE_MAC_LIST=""
+  export BLTCTL_COMMAND_DEVICES=""
   export BLECTL_FILE_INPUT=""
   export COLOR=true
   export ENABLE_HA_FEATURES=""

--- a/tesla_ble_mqtt/translations/en.yaml
+++ b/tesla_ble_mqtt/translations/en.yaml
@@ -2,9 +2,6 @@ configuration:
   vin_list:
     name: Single or multiple VINs separated by either of ,;| VIN found in Tesla app
     description: Single 5YJ3E1EB6JF111222 Multiple 5YJ3E1EB6JF111222|5YJ3E1EB6JF333444|...
-  ble_mac_list:
-    name: Single or multiple BLE MACs (aa:bb:cc:dd:ee:ff) separated by a | (pipe); Optional for proximity detection
-    description: Use Android "BLE scanner" or iOS "nRF Connect"; First locate your car's BLE Local Name, it starts with letter S and ends with C. In the app for the car, find the MAC address. If you have multiple Twsla cars, use the signal strength to figure out which one to pick.
   presence_detection_ttl:
     name: Presence detection TTL
     description: TTL in second when the car is considered gone after the last BLE ping; Default 240; 0 to disable detection

--- a/tesla_ble_mqtt/translations/fr.yaml
+++ b/tesla_ble_mqtt/translations/fr.yaml
@@ -5,9 +5,6 @@ configuration:
   ble_presence_detection_ttl:
     name: TTL ou le véhicule est considéré encore présent suite au dernier message reçu
     description: TTL en seconde pour considérer un véhicule non présent; Défault 240, mettre 0 pour désactivé la détection
-  ble_mac_list:
-    name: Une ou plusieurs BLE MACs (aa:bb:cc:dd:ee:ff) séparées par un , ou | ou espace blanc; Optionnel pour la détection de véhicule(s)
-    description: Utilisez Android "BLE scanner" ou iOS "nRF Connect"; 1) localiser le BLE Local Name de votre véhicule. Le nom commence par la lettre S et termine par C. Trouvez pour cette entrée le MAC Address. Si vous avez plusieurs véhicules, utiliser la puissance du signal pour déterminer lequel d'entre-eux chosir.
   mqtt_server:
     name: MQTT Serveur
     description: Adresse IP or Hostname pour le serveur MQTT


### PR DESCRIPTION
Detect car MAC address directly from VIN:
- Derive BLE LNAME from VIN (with 16 chars of sha256 sum)
- Implement bluetooth scan loop to parse LNAMEs & MACs
- Store MAC when detected