### PR TITLE
Add missing installation counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This repository contains the following add-ons
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
 
+![Reported Installations][installations-shield-stable]
+
 
 <!--
 Notes to developers after forking or using the github template feature:


### PR DESCRIPTION
So far on collected analytics by HA:

```
  "da013fb0_tesla_local_commands": {
    "total": 12,
    "versions": {
      "0.1.1": 12
    },
    "protected": 12,
    "auto_update": 1
  },
```